### PR TITLE
Fix comparison on i386

### DIFF
--- a/zcfan.c
+++ b/zcfan.c
@@ -190,7 +190,7 @@ static void maybe_ping_watchdog(void) {
     expect(clock_gettime(CLOCK_MONOTONIC, &now) == 0);
 
     if (now.tv_sec - last_watchdog_ping.tv_sec <
-        (watchdog_secs - WATCHDOG_GRACE_PERIOD_SECS)) {
+        (time_t)(watchdog_secs - WATCHDOG_GRACE_PERIOD_SECS)) {
         return;
     }
 


### PR DESCRIPTION
On x86 32-bit, `time_t` is a `long int`, and can't be compared directly
to `unsigned int` without casting the latter.

```
zcfan.c: In function 'maybe_ping_watchdog':
zcfan.c:192:48: error: comparison of integer expressions of different signedness: '__time_t' {aka 'long int'} and '
unsigned int' [-Werror=sign-compare]
  192 |     if (now.tv_sec - last_watchdog_ping.tv_sec <
      |                                                ^
cc1: all warnings being treated as errors
make[1]: *** [Makefile:17: zcfan] Error 1
```

On x86_64, for some reason we don't get this error, but
the cast is harmless on 64-bit so we can just apply it
unconditionally.

Signed-off-by: Michel Alexandre Salim <michel@michel-slm.name>