### PR TITLE
Fix wrong executable path based on Makefile provided values

### DIFF
--- a/zcfan.service
+++ b/zcfan.service
@@ -2,7 +2,7 @@
 Description=Zero-configuration fan control for ThinkPad
 
 [Service]
-ExecStart=/usr/bin/zcfan
+ExecStart=/usr/local/bin/zcfan
 Restart=always
 RestartSec=500ms
 


### PR DESCRIPTION
Fresh installation on PopOS 22.04, systemd service fails to start because the executable path is wrong. Based on default values provided in Makefile the path should include "local".

Error
Sep 09 11:52:48 E480 systemd[1]: Started Zero-configuration fan control for ThinkPad.
Sep 09 11:52:48 E480 systemd[10293]: zcfan.service: Failed to locate executable /usr/bin/zcfan: No >
Sep 09 11:52:48 E480 systemd[10293]: zcfan.service: Failed at step EXEC spawning /usr/bin/zcfan: No>
Sep 09 11:52:48 E480 systemd[1]: zcfan.service: Main process exited, code=exited, status=203/EXEC
Sep 09 11:52:48 E480 systemd[1]: zcfan.service: Failed with result 'exit-code'.
