### PR TITLE
Mark zcfan.service as conflicting with thinkfan.service

### DIFF
--- a/zcfan.service
+++ b/zcfan.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Zero-configuration fan control for ThinkPad
+Conflicts=thinkfan.service
 
 [Service]
 ExecStart=/usr/bin/zcfan


### PR DESCRIPTION
In Debian the two packages are marked as conflicting with each other: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1017980

In Fedora we don't - as Fedora defaults to not enabling installed services - and this does make it easier to install both side by side and test them back to back. Marking the services as conflicting makes sure that starting one stops the other and vice versa.

https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#Conflicts=