### PR TITLE
Make fan levels configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ the config parameter `temp_hysteresis`.
 To override these defaults, you can place a file at `/etc/zcfan.conf` with
 updated trip temperatures in degrees celsius. As an example:
 
+    max_level full-speed
+    med_level 4
+    low_level 1
     max_temp 85
     med_temp 70
     low_temp 55

--- a/README.md
+++ b/README.md
@@ -31,15 +31,16 @@ below the trip temperature for the current fan state. This can be tuned with
 the config parameter `temp_hysteresis`.
 
 To override these defaults, you can place a file at `/etc/zcfan.conf` with
-updated trip temperatures in degrees celsius. As an example:
+updated trip temperatures and/or fan levels in degrees celsius. As an example:
 
-    max_level full-speed
-    med_level 4
-    low_level 1
     max_temp 85
     med_temp 70
     low_temp 55
     temp_hysteresis 20
+
+    max_level full-speed
+    med_level 4
+    low_level 1
 
 ### Hysteresis
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ below the trip temperature for the current fan state. This can be tuned with
 the config parameter `temp_hysteresis`.
 
 To override these defaults, you can place a file at `/etc/zcfan.conf` with
-updated trip temperatures and/or fan levels in degrees celsius. As an example:
+updated trip temperatures in degrees celsius and/or fan levels. As an example:
 
     max_temp 85
     med_temp 70

--- a/zcfan.c
+++ b/zcfan.c
@@ -225,10 +225,12 @@ static void maybe_ping_watchdog(void) {
         }                                                                      \
     } while (0)
 
+#define CONFIG_MAX_STRLEN 15
+#define S_CONFIG_MAX_STRLEN STR(CONFIG_MAX_STRLEN)
 #define fscanf_str_for_key(f, pos, name, dest)                                 \
     do {                                                                       \
-        char val[256];                                                         \
-        if (fscanf(f, name " %255s ", val) == 1) {                             \
+        char val[CONFIG_MAX_STRLEN + 1];                                       \
+        if (fscanf(f, name " %" S_CONFIG_MAX_STRLEN "s ", val) == 1) {         \
             dest = strdup(val);                                                \
         } else {                                                               \
             expect(fseek(f, pos, SEEK_SET) == 0);                              \

--- a/zcfan.c
+++ b/zcfan.c
@@ -225,6 +225,16 @@ static void maybe_ping_watchdog(void) {
         }                                                                      \
     } while (0)
 
+#define fscanf_str_for_key(f, pos, name, dest)                                 \
+    do {                                                                       \
+        char val[256];                                                         \
+        if (fscanf(f, name " %255s ", val) == 1) {                             \
+            dest = strdup(val);                                                \
+        } else {                                                               \
+            expect(fseek(f, pos, SEEK_SET) == 0);                              \
+        }                                                                      \
+    } while (0)
+
 static void get_config(void) {
     FILE *f;
 
@@ -246,6 +256,9 @@ static void get_config(void) {
         fscanf_int_for_key(f, pos, "low_temp", rules[FAN_LOW].threshold);
         fscanf_int_for_key(f, pos, "watchdog_secs", watchdog_secs);
         fscanf_int_for_key(f, pos, "temp_hysteresis", temp_hysteresis);
+        fscanf_str_for_key(f, pos, "max_level", rules[FAN_MAX].tpacpi_level);
+        fscanf_str_for_key(f, pos, "med_level", rules[FAN_MED].tpacpi_level);
+        fscanf_str_for_key(f, pos, "low_level", rules[FAN_LOW].tpacpi_level);
         if (ftell(f) == pos) {
             while ((ch = fgetc(f)) != EOF && ch != '\n') {}
         }

--- a/zcfan.c
+++ b/zcfan.c
@@ -31,10 +31,13 @@
         }                                                                      \
     } while (0)
 
+#define CONFIG_MAX_STRLEN 15
+#define S_CONFIG_MAX_STRLEN STR(CONFIG_MAX_STRLEN)
+
 /* Must be highest to lowest temp */
 enum FanLevel { FAN_MAX, FAN_MED, FAN_LOW, FAN_OFF, FAN_INVALID };
 struct Rule {
-    const char *tpacpi_level;
+    char tpacpi_level[CONFIG_MAX_STRLEN + 1];
     int threshold;
     const char *name;
 };
@@ -225,13 +228,12 @@ static void maybe_ping_watchdog(void) {
         }                                                                      \
     } while (0)
 
-#define CONFIG_MAX_STRLEN 15
-#define S_CONFIG_MAX_STRLEN STR(CONFIG_MAX_STRLEN)
 #define fscanf_str_for_key(f, pos, name, dest)                                 \
     do {                                                                       \
         char val[CONFIG_MAX_STRLEN + 1];                                       \
         if (fscanf(f, name " %" S_CONFIG_MAX_STRLEN "s ", val) == 1) {         \
-            dest = strdup(val);                                                \
+            strncpy(dest, val, CONFIG_MAX_STRLEN);                             \
+            dest[CONFIG_MAX_STRLEN] = '\0';                                    \
         } else {                                                               \
             expect(fseek(f, pos, SEEK_SET) == 0);                              \
         }                                                                      \
@@ -312,7 +314,8 @@ int main(int argc, char *argv[]) {
 
     if (!full_speed_supported()) {
         err("level \"full-speed\" not supported, using level 7\n");
-        rules[FAN_MAX].tpacpi_level = "7";
+        strncpy(rules[FAN_MAX].tpacpi_level, "7", CONFIG_MAX_STRLEN);
+        rules[FAN_MAX].tpacpi_level[CONFIG_MAX_STRLEN] = '\0';
     }
 
     write_watchdog_timeout(watchdog_secs);


### PR DESCRIPTION
_(Love this project! I started looking at `thinkfan` and the config file had me running away to find something else.)_

I realize you're trying to keep feature creep down for this project, but would you possibly consider allowing the fan levels to be configurable? I'm running this patch locally.

This is my attempt at implementing this, so that you can for example specify this in the config file:

```
max_level full-speed
med_level 5
low_level 3
```