### PR TITLE
watchdog: Reset timer instead of writing fan level to avoid spinup

### DIFF
--- a/zcfan.c
+++ b/zcfan.c
@@ -213,8 +213,9 @@ static void maybe_ping_watchdog(void) {
         return;
     }
 
-    expect(current_rule); /* Already set up on first run by set_fan_level */
-    write_fan_level(current_rule->tpacpi_level);
+    // Transitioning from level 0 -> level 0 can cause a brief fan spinup on
+    // some models, so don't reset the timer by write_fan_level().
+    write_watchdog_timeout(watchdog_secs);
 }
 
 #define CONFIG_PATH "/etc/zcfan.conf"


### PR DESCRIPTION
On certain ThinkPad models like the E14 and T495, setting level 0 again when already at level 0 briefly spins up the fans.

To avoid this, change the behaviour to write the watchdog timeout when we are close to expiration rather than setting the level again.

Closes #32. Also see https://github.com/vmatare/thinkfan/issues/114.